### PR TITLE
Feature/version string

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ install:
  - go get -v -u golang.org/x/lint/golint
 
 script:
+ - tapirx -version
  - go test
  - test -z "$(gofmt -l -e .)" || (echo "gofmt failed"; false)
  - LINT="$(golint)"; test -z "$LINT" || (echo "$LINT"; false)

--- a/main.go
+++ b/main.go
@@ -69,12 +69,6 @@ import (
 var logger *log.Logger
 var verbose bool
 
-// ProductName is the human-readable name to be shown to the user.
-const ProductName = "Tapirx"
-
-// Version number, filled in via ldflags
-var Version string
-
 func setupLogging(debug bool) {
 	var traceDest io.Writer
 	traceDest = ioutil.Discard

--- a/version.go
+++ b/version.go
@@ -1,0 +1,10 @@
+package main
+
+// ProductName is the human-readable name to be shown to the user.
+const ProductName = "Tapirx"
+
+// Version is the SemVer version number number.
+//
+// You can overwrite the version number during development with
+//     go install -ldflags "-X main.Version=..."
+var Version = "1.0.0"


### PR DESCRIPTION
Ensures there's always a version string, even when building with `go get` instead of the Makefile. Before this, we had:

    $ go get github.com/virtalabs/tapirx
    $ tapirx -version
    Tapirx 

(I just confirmed this against the master branch on a Raspberry Pi.)

Now we have whatever's in `version.go`.

    $ go get github.com/virtalabs/tapirx
    $ tapirx -version
    Tapirx 1.0.0