### PR TITLE
handle Ctrl-C by printing stats

### DIFF
--- a/main.go
+++ b/main.go
@@ -137,6 +137,11 @@ func main() {
 		os.Exit(0)
 	}
 
+	if *statsFlag {
+		// Print stats before exit via Ctrl-C-esque interrupt
+		registerInterruptHandler()
+	}
+
 	logger.Printf("starting %s %s (%s)\n", ProductName, Version, runtime.GOOS)
 	defer logger.Printf("exiting %s\n", ProductName)
 

--- a/signals.go
+++ b/signals.go
@@ -1,0 +1,24 @@
+// Copyright 2019 Virta Laboratories, Inc.  All rights reserved.
+/*
+Signal handling.
+*/
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/signal"
+)
+
+// registerInterruptHandler spawns a goroutine that listens for an interrupt
+// signal (e.g., Ctrl-C) and prints the global Stats object to standard output.
+func registerInterruptHandler() {
+	sig := make(chan os.Signal, 1)
+	signal.Notify(sig, os.Interrupt)
+	go func() {
+		<-sig // eat the signal
+		fmt.Println(stats.String())
+		os.Exit(0)
+	}()
+}

--- a/signals.go
+++ b/signals.go
@@ -9,13 +9,14 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"syscall"
 )
 
 // registerInterruptHandler spawns a goroutine that listens for an interrupt
 // signal (e.g., Ctrl-C) and prints the global Stats object to standard output.
 func registerInterruptHandler() {
 	sig := make(chan os.Signal, 1)
-	signal.Notify(sig, os.Interrupt)
+	signal.Notify(sig, syscall.SIGINT, syscall.SIGTERM)
 	go func() {
 		<-sig // eat the signal
 		fmt.Println(stats.String())


### PR DESCRIPTION
When in live capture mode with the `-stats` flag enabled (e.g., `tapirx -iface eth0 -stats`), the only way to exit from an interactive session is Ctrl-C, but unless we catch SIGINT, no stats will be printed! This PR fixes that situation by registering a signal handler in an idiomatic Go way that should work on all platforms.

To test:
```shell
$ make
$ tapirx -iface eth0 -stats
^C  # SIGINT; should print stats and exit with 0

$ tapirx -iface eth0 -stats &
$ killall tapirx  # SIGTERM; print stats and exit with 0

$ tapirx -iface eth0 -stats &
$ killall -KILL tapirx  # SIGKILL; no stats + nonzero exit
```