### PR TITLE
Change installation command for Tapirx

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ discovery out of the box:
 
 [Install Go](https://golang.org/doc/install), then install Tapirx:
 
-    $ go get -u -v github.com/virtalabs/tapirx
+    $ go install github.com/virtalabs/tapirx@latest
 
 If you already have Tapirx installed, the above command will update you to the
 latest version.


### PR DESCRIPTION
Updated installation command for Tapirx to use 'go install' with versioning.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation instructions to use the latest version tag.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->